### PR TITLE
Clean ups in eve infrastructure and improvements in code generation

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -14,6 +14,7 @@ jobs:
             matrix:
                 compiler: [gcc-9-atlas]
                 build_type: [Release]
+                python-version: [3.8]
 
         steps:
             - uses: actions/checkout@v1

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -14,14 +14,9 @@ jobs:
             matrix:
                 compiler: [gcc-9-atlas]
                 build_type: [Release]
-                python-version: [3.8]
 
         steps:
             - uses: actions/checkout@v1
-            - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v1
-              with:
-                  python-version: ${{ matrix.python-version }}
             - name: Install eve and dependencies
               run: |
                   ./scripts/init_env.sh -i

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
-default_language_version:
-    python: python3.7
+# default_language_version:
+#     python: python3.7
 repos:
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v2.5.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,5 @@
-# pre-commit config
+default_language_version:
+    python: python3.7
 repos:
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v2.5.0
@@ -8,11 +9,11 @@ repos:
           - id: check-yaml
           - id: fix-encoding-pragma
 
-    # - repo: https://github.com/asottile/seed-isort-config
-    #   rev: v1.9.3
-    #   hooks:
-    #       - id: seed-isort-config
-    #         args: [--application-directories=src]
+    - repo: https://github.com/asottile/seed-isort-config
+      rev: v1.9.3
+      hooks:
+          - id: seed-isort-config
+            args: [--application-directories=src]
 
     - repo: https://github.com/pre-commit/mirrors-isort
       rev: v4.3.21
@@ -30,10 +31,10 @@ repos:
           - id: flake8
             additional_dependencies:
                 [darglint, flake8-bugbear, flake8-builtins, flake8-docstrings]
-#
-# -   repo: https://github.com/pre-commit/mirrors-mypy
-#     rev: v0.761
-#     hooks:
-#     -   id: mypy
-#         exclude: ^install-local.py$
-#         additional_dependencies: [pydantic~=1.0]
+
+    - repo: https://github.com/pre-commit/mirrors-mypy
+      rev: v0.761
+      hooks:
+          - id: mypy
+            additional_dependencies: [pydantic~=1.0]
+            exclude: "(examples|src/gtc|tests)/.*"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,10 +31,9 @@ repos:
           - id: flake8
             additional_dependencies:
                 [darglint, flake8-bugbear, flake8-builtins, flake8-docstrings]
-
-    - repo: https://github.com/pre-commit/mirrors-mypy
-      rev: v0.761
-      hooks:
-          - id: mypy
-            additional_dependencies: [pydantic~=1.0]
-            exclude: "(examples|src/gtc|tests)/.*"
+    # - repo: https://github.com/pre-commit/mirrors-mypy
+    #   rev: v0.761
+    #   hooks:
+    #       - id: mypy
+    #         additional_dependencies: [pydantic~=1.0]
+    #         exclude: "(examples|src/gtc|tests)/.*"

--- a/requirements.in
+++ b/requirements.in
@@ -1,11 +1,11 @@
 
 black>=19.10b0
 boltons>=20.0
-dataclasses; python_version < "3.7"
 devtools>=0.5
 jinja2>=2.10
 lark-parser>=0.8
 mako>=1.1
+networkx>=2.4
 numpy>=1.17
 packaging>=20.0
 pybind11>=2.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -4,6 +4,7 @@
 #
 alabaster==0.7.12         # via sphinx
 appdirs==1.4.4            # via black, virtualenv
+argon2-cffi==20.1.0       # via notebook
 aspy.refactor-imports==2.1.1  # via seed-isort-config
 attrs==19.3.0             # via black, flake8-bugbear, jsonschema, pytest
 babel==2.8.0              # via sphinx
@@ -11,22 +12,22 @@ backcall==0.2.0           # via ipython
 beautifulsoup4==4.9.1     # via sphinx-material
 black==19.10b0            # via -r /home/enriqueg/Projects/eve/requirements.in
 bleach==3.1.5             # via nbconvert
-boltons==20.2.0           # via -r /home/enriqueg/Projects/eve/requirements.in
+boltons==20.2.1           # via -r /home/enriqueg/Projects/eve/requirements.in
 cached-property==1.5.1    # via aspy.refactor-imports
 certifi==2020.6.20        # via requests
-cfgv==3.1.0               # via pre-commit
+cffi==1.14.2              # via argon2-cffi
+cfgv==3.2.0               # via pre-commit
 chardet==3.0.4            # via requests
 check-manifest==0.42      # via -r /home/enriqueg/Projects/eve/requirements_dev.in
 clang-format==9.0.0       # via -r /home/enriqueg/Projects/eve/requirements.in
 click==7.1.2              # via black, pip-tools
-coverage==5.2             # via -r /home/enriqueg/Projects/eve/requirements_dev.in, pytest-cov
-cppimport==18.11.8        # via -r /home/enriqueg/Projects/eve/requirements_dev.in
+coverage==5.2.1           # via -r /home/enriqueg/Projects/eve/requirements_dev.in, pytest-cov
+cppimport==20.8.4.2       # via -r /home/enriqueg/Projects/eve/requirements_dev.in
 css-html-js-minify==2.5.5  # via sphinx-material
-darglint==1.5.1           # via -r /home/enriqueg/Projects/eve/requirements_dev.in
-dataclasses==0.7 ; python_version < "3.7"  # via -r /home/enriqueg/Projects/eve/requirements.in, pydantic
-decorator==4.4.2          # via ipython, traitlets
+darglint==1.5.2           # via -r /home/enriqueg/Projects/eve/requirements_dev.in
+decorator==4.4.2          # via ipython, networkx, traitlets
 defusedxml==0.6.0         # via nbconvert
-devtools==0.5.1           # via -r /home/enriqueg/Projects/eve/requirements.in
+devtools==0.6             # via -r /home/enriqueg/Projects/eve/requirements.in
 distlib==0.3.1            # via virtualenv
 docutils==0.16            # via sphinx
 entrypoints==0.3          # via nbconvert
@@ -36,16 +37,16 @@ flake8-bugbear==20.1.4    # via -r /home/enriqueg/Projects/eve/requirements_dev.
 flake8-builtins==1.5.3    # via -r /home/enriqueg/Projects/eve/requirements_dev.in
 flake8-docstrings==1.5.0  # via -r /home/enriqueg/Projects/eve/requirements_dev.in
 flake8==3.8.3             # via -r /home/enriqueg/Projects/eve/requirements_dev.in, flake8-bugbear, flake8-builtins, flake8-docstrings
-identify==1.4.24          # via pre-commit
+identify==1.4.28          # via pre-commit
 idna==2.10                # via requests
 imagesize==1.2.0          # via sphinx
 importlib-metadata==1.7.0  # via flake8, jsonschema, pep517, pluggy, pre-commit, pytest, tox, virtualenv
-importlib-resources==3.0.0  # via pre-commit, virtualenv
-ipykernel==5.3.3          # via -r /home/enriqueg/Projects/eve/requirements_dev.in, ipywidgets, jupyter, jupyter-console, notebook, qtconsole
+iniconfig==1.0.1          # via pytest
+ipykernel==5.3.4          # via -r /home/enriqueg/Projects/eve/requirements_dev.in, ipywidgets, jupyter, jupyter-console, notebook, qtconsole
 ipython-genutils==0.2.0   # via nbformat, notebook, qtconsole, traitlets
-ipython==7.16.1           # via -r /home/enriqueg/Projects/eve/requirements_dev.in, ipykernel, ipywidgets, jupyter-console
+ipython==7.17.0           # via -r /home/enriqueg/Projects/eve/requirements_dev.in, ipykernel, ipywidgets, jupyter-console
 ipywidgets==7.5.1         # via jupyter
-isort==5.1.4              # via -r /home/enriqueg/Projects/eve/requirements_dev.in
+isort==5.4.2              # via -r /home/enriqueg/Projects/eve/requirements_dev.in
 jedi==0.17.2              # via ipython
 jinja2==2.11.2            # via -r /home/enriqueg/Projects/eve/requirements.in, jupyterlab, jupyterlab-server, nbconvert, notebook, sphinx
 json5==0.9.5              # via jupyterlab-server
@@ -55,9 +56,9 @@ jupyter-console==6.1.0    # via jupyter
 jupyter-core==4.6.3       # via jupyter-client, nbconvert, nbformat, notebook, qtconsole
 jupyter==1.0.0            # via -r /home/enriqueg/Projects/eve/requirements_dev.in
 jupyterlab-server==1.2.0  # via jupyterlab
-jupyterlab==2.2.0         # via -r /home/enriqueg/Projects/eve/requirements_dev.in
+jupyterlab==2.2.5         # via -r /home/enriqueg/Projects/eve/requirements_dev.in
 lark-parser==0.9.0        # via -r /home/enriqueg/Projects/eve/requirements.in
-lit==0.10.0               # via -r /home/enriqueg/Projects/eve/requirements_dev.in
+lit==0.10.1.post1         # via -r /home/enriqueg/Projects/eve/requirements_dev.in
 lxml==4.5.2               # via sphinx-material
 mako==1.1.3               # via -r /home/enriqueg/Projects/eve/requirements.in, cppimport
 markupsafe==1.1.1         # via jinja2, mako
@@ -68,50 +69,52 @@ mypy-extensions==0.4.3    # via mypy
 mypy==0.782               # via -r /home/enriqueg/Projects/eve/requirements_dev.in
 nbconvert==5.6.1          # via jupyter, notebook
 nbformat==5.0.7           # via ipywidgets, nbconvert, notebook
+networkx==2.4             # via -r /home/enriqueg/Projects/eve/requirements.in
 nodeenv==1.4.0            # via pre-commit
-notebook==6.0.3           # via jupyter, jupyterlab, jupyterlab-server, widgetsnbextension
-numpy==1.19.0             # via -r /home/enriqueg/Projects/eve/requirements.in
+notebook==6.1.3           # via jupyter, jupyterlab, jupyterlab-server, widgetsnbextension
+numpy==1.19.1             # via -r /home/enriqueg/Projects/eve/requirements.in
 packaging==20.4           # via -r /home/enriqueg/Projects/eve/requirements.in, bleach, pytest, sphinx, tox
 pandocfilters==1.4.2      # via nbconvert
-parso==0.7.0              # via jedi
+parso==0.7.1              # via jedi
 pathspec==0.8.0           # via black
 pep517==0.8.2             # via check-manifest
 pexpect==4.8.0            # via ipython
 pickleshare==0.7.5        # via ipython
-pip-tools==5.2.1          # via -r /home/enriqueg/Projects/eve/requirements_dev.in
+pip-tools==5.3.1          # via -r /home/enriqueg/Projects/eve/requirements_dev.in
 pluggy==0.13.1            # via pytest, tox
 pre-commit==2.6.0         # via -r /home/enriqueg/Projects/eve/requirements_dev.in
 prometheus-client==0.8.0  # via notebook
-prompt-toolkit==3.0.5     # via ipython, jupyter-console
+prompt-toolkit==3.0.6     # via ipython, jupyter-console
 ptyprocess==0.6.0         # via pexpect, terminado
 py==1.9.0                 # via pytest, tox
 pybind11==2.5.0           # via -r /home/enriqueg/Projects/eve/requirements.in, cppimport
 pycodestyle==2.6.0        # via flake8
+pycparser==2.20           # via cffi
 pydantic==1.6.1           # via -r /home/enriqueg/Projects/eve/requirements.in
 pydocstyle==5.0.2         # via flake8-docstrings
 pyflakes==2.2.0           # via flake8
 pygments==2.6.1           # via ipython, jupyter-console, nbconvert, qtconsole, sphinx
 pyparsing==2.4.7          # via packaging
 pyrsistent==0.16.0        # via jsonschema
-pytest-cov==2.10.0        # via -r /home/enriqueg/Projects/eve/requirements_dev.in
-pytest==5.4.3             # via -r /home/enriqueg/Projects/eve/requirements_dev.in, pytest-cov
+pytest-cov==2.10.1        # via -r /home/enriqueg/Projects/eve/requirements_dev.in
+pytest==6.0.1             # via -r /home/enriqueg/Projects/eve/requirements_dev.in, pytest-cov
 python-dateutil==2.8.1    # via jupyter-client
 python-slugify[unidecode]==4.0.1  # via sphinx-material
 pytz==2020.1              # via babel
 pyyaml==5.3.1             # via pre-commit
-pyzmq==19.0.1             # via jupyter-client, notebook, qtconsole
-qtconsole==4.7.5          # via jupyter
+pyzmq==19.0.2             # via jupyter-client, notebook, qtconsole
+qtconsole==4.7.6          # via jupyter
 qtpy==1.9.0               # via qtconsole
 regex==2020.7.14          # via black
 requests==2.24.0          # via jupyterlab-server, sphinx
 seed-isort-config==2.2.0  # via -r /home/enriqueg/Projects/eve/requirements_dev.in
 send2trash==1.5.0         # via notebook
-six==1.15.0               # via bleach, jsonschema, packaging, pip-tools, python-dateutil, tox, traitlets, virtualenv
+six==1.15.0               # via argon2-cffi, bleach, jsonschema, packaging, pip-tools, pyrsistent, python-dateutil, tox, traitlets, virtualenv
 snowballstemmer==2.0.0    # via pydocstyle, sphinx
 soupsieve==2.0.1          # via beautifulsoup4
 sphinx-material==0.0.30   # via -r /home/enriqueg/Projects/eve/requirements_dev.in
 sphinx-rtd-theme==0.5.0   # via -r /home/enriqueg/Projects/eve/requirements_dev.in
-sphinx==3.1.2             # via -r /home/enriqueg/Projects/eve/requirements_dev.in, sphinx-material, sphinx-rtd-theme
+sphinx==3.2.1             # via -r /home/enriqueg/Projects/eve/requirements_dev.in, sphinx-material, sphinx-rtd-theme
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx
@@ -121,20 +124,20 @@ sphinxcontrib-serializinghtml==1.1.4  # via sphinx
 terminado==0.8.3          # via notebook
 testpath==0.4.4           # via nbconvert
 text-unidecode==1.3       # via python-slugify
-toml==0.10.1              # via black, check-manifest, pep517, pre-commit, tox
+toml==0.10.1              # via black, check-manifest, pep517, pre-commit, pytest, tox
 tornado==6.0.4            # via ipykernel, jupyter-client, jupyterlab, notebook, terminado
-tox==3.17.1               # via -r /home/enriqueg/Projects/eve/requirements_dev.in
+tox==3.19.0               # via -r /home/enriqueg/Projects/eve/requirements_dev.in
 traitlets==4.3.3          # via ipykernel, ipython, ipywidgets, jupyter-client, jupyter-core, nbconvert, nbformat, notebook, qtconsole
 typed-ast==1.4.1          # via black, mypy
 typing-extensions==3.7.4.2  # via -r /home/enriqueg/Projects/eve/requirements.in, mypy
 unidecode==1.1.1          # via python-slugify
-urllib3==1.25.9           # via requests
-virtualenv==20.0.27       # via pre-commit, tox
-wcwidth==0.2.5            # via prompt-toolkit, pytest
+urllib3==1.25.10          # via requests
+virtualenv==20.0.31       # via pre-commit, tox
+wcwidth==0.2.5            # via prompt-toolkit
 webencodings==0.5.1       # via bleach
 widgetsnbextension==3.5.1  # via ipywidgets
-xxhash==1.4.4             # via -r /home/enriqueg/Projects/eve/requirements.in
-zipp==3.1.0               # via importlib-metadata, importlib-resources, pep517
+xxhash==2.0.0             # via -r /home/enriqueg/Projects/eve/requirements.in
+zipp==3.1.0               # via importlib-metadata, pep517
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -44,7 +44,7 @@ importlib-metadata==1.7.0  # via flake8, jsonschema, pep517, pluggy, pre-commit,
 iniconfig==1.0.1          # via pytest
 ipykernel==5.3.4          # via -r /home/enriqueg/Projects/eve/requirements_dev.in, ipywidgets, jupyter, jupyter-console, notebook, qtconsole
 ipython-genutils==0.2.0   # via nbformat, notebook, qtconsole, traitlets
-ipython==7.17.0           # via -r /home/enriqueg/Projects/eve/requirements_dev.in, ipykernel, ipywidgets, jupyter-console
+ipython==7.16.1           # via -r /home/enriqueg/Projects/eve/requirements_dev.in, ipykernel, ipywidgets, jupyter-console
 ipywidgets==7.5.1         # via jupyter
 isort==5.4.2              # via -r /home/enriqueg/Projects/eve/requirements_dev.in
 jedi==0.17.2              # via ipython

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -44,7 +44,7 @@ importlib-metadata==1.7.0  # via flake8, jsonschema, pep517, pluggy, pre-commit,
 iniconfig==1.0.1          # via pytest
 ipykernel==5.3.4          # via -r /home/enriqueg/Projects/eve/requirements_dev.in, ipywidgets, jupyter, jupyter-console, notebook, qtconsole
 ipython-genutils==0.2.0   # via nbformat, notebook, qtconsole, traitlets
-ipython==7.16.1           # via -r /home/enriqueg/Projects/eve/requirements_dev.in, ipykernel, ipywidgets, jupyter-console
+ipython==7.17.0           # via -r /home/enriqueg/Projects/eve/requirements_dev.in, ipykernel, ipywidgets, jupyter-console
 ipywidgets==7.5.1         # via jupyter
 isort==5.4.2              # via -r /home/enriqueg/Projects/eve/requirements_dev.in
 jedi==0.17.2              # via ipython

--- a/setup.cfg
+++ b/setup.cfg
@@ -82,7 +82,7 @@ exclude_lines =
 ignore_errors = True
 
 [coverage:html]
-directory = _local/coverage_html
+directory = tests/coverage_html
 
 
 #-- darglint --

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ classifiers =
   License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)
   Operating System :: POSIX
   Programming Language :: Python
-  Programming Language :: Python :: 3.6
   Programming Language :: Python :: 3.7
   Programming Language :: Python :: 3.8
   Programming Language :: Python :: Implementation :: CPython
@@ -36,11 +35,10 @@ include_package_data = True
 packages = find:
 package_dir=
   =src
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
   black>=19.10b0
   boltons>=20.0
-  dataclasses; python_version < "3.7"
   devtools>=0.5
   jinja2>=2.10
   lark-parser>=0.8
@@ -123,7 +121,7 @@ lines_after_imports = 2
 default_section = THIRDPARTY
 sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 known_first_party = eve,gtc
-known_third_party = black,boltons,devtools,jinja2,mako,packaging,pydantic,pytest,setuptools,sphinx_material,typing_extensions,xxhash
+known_third_party = atlas4py,black,boltons,cppimport,devtools,fvm_nabla_wrapper,jinja2,mako,networkx,numpy,packaging,pydantic,pytest,setuptools,sphinx_material,xxhash
 
 
 #-- mypy --

--- a/src/eve/__init__.py
+++ b/src/eve/__init__.py
@@ -16,10 +16,11 @@
 
 """Eve: a stencil toolchain in pure Python."""
 
-from .version import __version__, __versioninfo__  # noqa isort:skip
+# flake8: noqa
+from .version import __version__, __versioninfo__  # isort:skip
 
-from . import codegen, exceptions, traits, utils  # noqa: F401
-from .concepts import (  # noqa: F401
+from . import codegen, concepts, exceptions, traits, types, typing, utils
+from .concepts import (
     FieldKind,
     FrozenModel,
     FrozenNode,
@@ -34,8 +35,8 @@ from .concepts import (  # noqa: F401
     symbol_field,
     validator,
 )
-from .tree_utils import FindNodes  # noqa: F401
-from .types import (  # noqa: F401
+from .tree_utils import FindNodes
+from .types import (
     Bool,
     Bytes,
     Enum,
@@ -52,7 +53,6 @@ from .types import (  # noqa: F401
     StrictFloat,
     StrictInt,
     StrictStr,
-    classproperty,
 )
-from .utils import NOTHING  # noqa: F401
-from .visitors import NodeModifier, NodeTranslator, NodeVisitor, PathNodeVisitor  # noqa: F401
+from .utils import NOTHING
+from .visitors import NodeModifier, NodeTranslator, NodeVisitor, PathNodeVisitor

--- a/src/eve/concepts.py
+++ b/src/eve/concepts.py
@@ -20,32 +20,26 @@
 import abc
 import functools
 import itertools
-import typing
-from typing import (  # noqa: F401
-    Any,
-    Callable,
-    ClassVar,
-    Collection,
-    Dict,
-    Generator,
-    Iterable,
-    List,
-    Mapping,
-    MutableSequence,
-    MutableSet,
-    Optional,
-    Sequence,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-    no_type_check,
-)
 
 import pydantic
 from pydantic import BaseModel, validator
 
-from .types import NoArgAnyCallable, PositiveInt, Str, StrEnum, TypedDict
+from . import typing
+from .types import PositiveInt, Str, StrEnum
+from .typing import (
+    Any,
+    AnyNoArgCallable,
+    ClassVar,
+    Dict,
+    Generator,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    TypedDict,
+    Union,
+    no_type_check,
+)
 from .utils import NOTHING
 
 
@@ -73,7 +67,7 @@ _EVE_METADATA_KEY = "__eve_meta"
 def field(
     default: Any = NOTHING,
     *,
-    default_factory: Optional[NoArgAnyCallable] = None,
+    default_factory: Optional[AnyNoArgCallable] = None,
     kind: Optional[FieldKind] = None,
     constraints: Optional[FieldConstraintsDict] = None,
     schema_config: Dict[str, Any] = None,

--- a/src/eve/exceptions.py
+++ b/src/eve/exceptions.py
@@ -16,7 +16,7 @@
 
 """Definitions of specific Eve exceptions."""
 
-from typing import Any
+from .typing import Any
 
 
 class EveError:
@@ -32,12 +32,12 @@ class EveError:
 
 
 class EveTypeError(EveError, TypeError):
-    message_template = "Invalid or unexpected type (info: {info}) "
+    message_template = "Invalid or unexpected type (info: {info})"
 
 
 class EveValueError(EveError, ValueError):
-    message_template = "Invalid value (info: {info}) "
+    message_template = "Invalid value (info: {info})"
 
 
 class EveRuntimeError(EveError, RuntimeError):
-    message_template = "Runtime error (info: {info}) "
+    message_template = "Runtime error (info: {info})"

--- a/src/eve/traits.py
+++ b/src/eve/traits.py
@@ -17,11 +17,10 @@
 """Definitions of basic Eve concepts."""
 
 
-from typing import Any, ClassVar, Dict, List, Type
-
 import pydantic
 
 from .concepts import _EVE_NODE_ATTR_SUFFIX, Node, Trait
+from .typing import Any, ClassVar, Dict, List, Type
 
 
 class SymbolTableTrait(Trait):

--- a/src/eve/tree_utils.py
+++ b/src/eve/tree_utils.py
@@ -14,9 +14,8 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Any, Callable, Type
-
 from .concepts import Node
+from .typing import Any, Callable, Type
 from .visitors import NodeVisitor
 
 

--- a/src/eve/tree_utils.py
+++ b/src/eve/tree_utils.py
@@ -15,27 +15,27 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from .concepts import Node
-from .typing import Any, Callable, Type
-from .visitors import NodeVisitor
+from .typing import Any, Callable, List, Type
+from .visitors import AnyTreeNode, NodeVisitor
 
 
 class FindNodes(NodeVisitor):
-    def __init__(self, **kwargs):
-        self.result = []
+    def __init__(self, **kwargs: Any) -> None:
+        self.result: List = []
 
-    def visit(self, node: Node, **kwargs) -> Any:
+    def visit(self, node: AnyTreeNode, **kwargs: Any) -> Any:
         if kwargs["predicate"](node):
             self.result.append(node)
         self.generic_visit(node, **kwargs)
         return self.result
 
     @classmethod
-    def by_predicate(cls, predicate: Callable[[Node], bool], node: Node, **kwargs):
+    def by_predicate(cls, predicate: Callable[[Node], bool], node: Node, **kwargs: Any) -> Any:
         return cls().visit(node, predicate=predicate)
 
     @classmethod
-    def by_type(cls, node_type: Type[Node], node: Node, **kwargs):
-        def type_predicate(node: Node):
+    def by_type(cls, node_type: Type[Node], node: Node, **kwargs: Any) -> Any:
+        def type_predicate(node: Node) -> bool:
             return isinstance(node, node_type)
 
         return cls.by_predicate(type_predicate, node)

--- a/src/eve/types.py
+++ b/src/eve/types.py
@@ -14,15 +14,12 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-"""Definitions of general infrastructure."""
+"""Definitions of useful types."""
 
 
 import enum
-import sys
-from typing import Any, Callable, Generator
 
-import boltons.typeutils
-import pydantic
+from boltons.typeutils import classproperty  # noqa: F401
 from pydantic import (  # noqa: F401
     NegativeFloat,
     NegativeInt,
@@ -35,17 +32,11 @@ from pydantic import (  # noqa: F401
     validator,
 )
 
-
-if sys.version_info < (3, 8):
-    from typing_extensions import Literal, TypedDict  # noqa: F401
-else:
-    from typing import Literal, TypedDict  # noqa: F401
-
-AnyCallable = Callable[..., Any]
-NoArgAnyCallable = Callable[[], Any]
+from .typing import Any, Callable, Generator
 
 
-classproperty = boltons.typeutils.classproperty
+#: Typing definitions for `__get_validators__()` methods (defined but not exported in `pydantic.typing`)
+PydanticCallableGenerator = Generator[Callable[..., Any], None, None]
 
 
 #: :class:`bool subclass for strict field definition
@@ -58,10 +49,6 @@ Float = StrictFloat  # noqa: F401
 Int = StrictInt  # noqa: F401
 #: :class:`str` subclass for strict field definition
 Str = StrictStr  # noqa: F401
-
-
-#: Typing hint for `__get_validators__()` methods (defined but not exported in `pydantic.typing`)
-PydanticCallableGenerator = Generator[pydantic.typing.AnyCallable, None, None]
 
 
 class Enum(enum.Enum):

--- a/src/eve/typing.py
+++ b/src/eve/typing.py
@@ -22,7 +22,7 @@ from typing import *  # isort:skip
 import sys  # isort:skip
 
 if sys.version_info < (3, 8):
-    from typing_extensions import Literal, Protocol, TypedDict
+    from typing_extensions import Literal, Protocol, TypedDict  # type: ignore
 
 del sys
 

--- a/src/eve/typing.py
+++ b/src/eve/typing.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+#
+# Eve Toolchain - GT4Py Project - GridTools Framework
+#
+# Copyright (c) 2020, CSCS - Swiss National Supercomputing Center, ETH Zurich
+# All rights reserved.
+#
+# This file is part of the GT4Py project and the GridTools framework.
+# GT4Py is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or any later
+# version. See the LICENSE.txt file at the top-level directory of this
+# distribution for a copy of the license or check <https://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Definitions of useful typing."""
+
+# flake8: noqa
+from typing import *  # isort:skip
+
+import sys  # isort:skip
+
+if sys.version_info < (3, 8):
+    from typing_extensions import Literal, Protocol, TypedDict
+
+del sys
+
+T = TypeVar("T")
+FrozenList = Tuple[T, ...]
+
+
+AnyCallable = Callable[..., Any]
+AnyNoneCallable = Callable[..., None]
+AnyNoArgCallable = Callable[[], Any]

--- a/src/eve/utils.py
+++ b/src/eve/utils.py
@@ -18,8 +18,6 @@
 
 
 import collections.abc
-import typing
-from typing import Any, Callable, Iterable, Optional, Sequence, Union
 
 import xxhash
 from boltons.iterutils import flatten, flatten_iter  # noqa: F401
@@ -49,6 +47,9 @@ from boltons.strutils import (  # noqa: F401
     unwrap_text,
 )
 
+from . import typing
+from .typing import Any, Callable, Iterable, Optional, Union
+
 
 class _NOTHING_TYPE:
     pass
@@ -67,37 +68,37 @@ def call_all(funcs_iterable: Iterable[Callable]) -> Callable:
     return _caller
 
 
-WordSequenceType = Union[str, Sequence[str]]
+AnyWordsIterable = Union[str, Iterable[str]]
 
 
-def join_canonical_cased(words: WordSequenceType) -> str:
+def join_canonical_cased(words: AnyWordsIterable) -> str:
     words = [words] if isinstance(words, str) else words
     return (" ".join(words)).lower()
 
 
-def join_concatcased(words: WordSequenceType) -> str:
+def join_concatcased(words: AnyWordsIterable) -> str:
     words = [words] if isinstance(words, str) else words
-    return "".join(words)
+    return "".join(word.lower() for word in words)
 
 
-def join_camelCased(words: WordSequenceType) -> str:
-    words = [words] if isinstance(words, str) else words
-    return words[0] + "".join(word.title() for word in words[1:])
+def join_camelCased(words: AnyWordsIterable) -> str:
+    words = [words] if isinstance(words, str) else list(words)
+    return words[0].lower() + "".join(word.title() for word in words[1:])
 
 
-def join_CamelCased(words: WordSequenceType) -> str:
+def join_PascalCased(words: AnyWordsIterable) -> str:
     words = [words] if isinstance(words, str) else words
     return "".join(word.title() for word in words)
 
 
-def join_SNAKE_CASED(words: WordSequenceType) -> str:
+def join_snake_cased(words: AnyWordsIterable) -> str:
     words = [words] if isinstance(words, str) else words
-    return "_".join(word for word in words).upper()
+    return "_".join(words).lower()
 
 
-def join_snake_cased(words: WordSequenceType) -> str:
+def join_kebab_cased(words: AnyWordsIterable) -> str:
     words = [words] if isinstance(words, str) else words
-    return "_".join(words)
+    return "-".join(words).lower()
 
 
 def shash(*args: Any, hash_algorithm: Optional[Any] = None, str_encoding: str = "utf-8") -> str:

--- a/src/eve/visitors.py
+++ b/src/eve/visitors.py
@@ -22,7 +22,10 @@ import copy
 import dataclasses
 import enum
 import operator
-from typing import (
+
+from .concepts import Node
+from .types import IntEnum, StrEnum
+from .typing import (
     Any,
     Callable,
     Collection,
@@ -32,16 +35,15 @@ from typing import (
     MutableSet,
     Optional,
     Tuple,
+    TypeVar,
     Union,
 )
-
-from .concepts import Node
-from .types import IntEnum, StrEnum
 from .utils import NOTHING
 
 
-ValidLeafNodeType = Union[bool, bytes, int, float, str, IntEnum, StrEnum, Node, None]
-ValidNodeType = Union[ValidLeafNodeType, Collection[ValidLeafNodeType]]
+AnyNode = TypeVar("AnyNode", bound=Node)
+AnyTreeLeaf = Union[bool, bytes, int, float, str, IntEnum, StrEnum, Node, AnyNode]
+AnyTreeNode = Union[AnyTreeLeaf, Collection[AnyTreeLeaf]]
 
 
 class NodeVisitor:
@@ -68,7 +70,7 @@ class NodeVisitor:
 
     ATOMIC_COLLECTION_TYPES = (str, bytes, bytearray)
 
-    def visit(self, node: ValidNodeType, **kwargs: Any) -> Any:
+    def visit(self, node: AnyTreeNode, **kwargs: Any) -> Any:
         visitor = self.generic_visit
         if isinstance(node, Node):
             for node_class in node.__class__.__mro__:
@@ -82,7 +84,7 @@ class NodeVisitor:
 
         return visitor(node, **kwargs)
 
-    def generic_visit(self, node: ValidNodeType, **kwargs: Any) -> Any:
+    def generic_visit(self, node: AnyTreeNode, **kwargs: Any) -> Any:
         items: Iterable[Tuple[Any, Any]] = []
         if isinstance(node, Node):
             items = list(node.iter_children())
@@ -117,16 +119,16 @@ class NodeTranslator(NodeVisitor):
        node = YourTranslator().visit(node)
     """
 
-    def __init__(self, *, memo: dict = None, **kwargs: Any):
+    def __init__(self, *, memo: dict = None, **kwargs: Any) -> None:
         assert memo is None or isinstance(memo, dict)
         self.memo = memo or {}
 
-    def generic_visit(self, node: ValidNodeType, **kwargs: Any) -> Any:
+    def generic_visit(self, node: AnyTreeNode, **kwargs: Any) -> Any:
         result: Any
         if isinstance(node, (Node, collections.abc.Collection)) and not isinstance(
             node, self.ATOMIC_COLLECTION_TYPES
         ):
-            tmp_items: Collection[ValidNodeType] = []
+            tmp_items: Collection[AnyTreeNode] = []
             if isinstance(node, Node):
                 tmp_items = {
                     key: self.visit(value, **kwargs) for key, value in node.iter_children()
@@ -175,13 +177,13 @@ class NodeModifier(NodeVisitor):
        node = YourTransformer().visit(node)
     """
 
-    def generic_visit(self, node: ValidNodeType, **kwargs: Any) -> Any:
+    def generic_visit(self, node: AnyTreeNode, **kwargs: Any) -> Any:
         result: Any = node
         if isinstance(node, (Node, collections.abc.Collection)) and not isinstance(
             node, self.ATOMIC_COLLECTION_TYPES
         ):
             items: Iterable[Tuple[Any, Any]] = []
-            tmp_items: Collection[ValidNodeType] = []
+            tmp_items: Collection[AnyTreeNode] = []
             set_op: Union[Callable[[Any, str, Any], None], Callable[[Any, int, Any], None]]
             del_op: Union[Callable[[Any, str], None], Callable[[Any, int], None]]
 
@@ -193,7 +195,7 @@ class NodeModifier(NodeVisitor):
                 items = enumerate(node)
                 index_shift = 0
 
-                def set_op(container: MutableSequence, idx: int, value: ValidNodeType) -> None:
+                def set_op(container: MutableSequence, idx: int, value: AnyTreeNode) -> None:
                     container[idx - index_shift] = value
 
                 def del_op(container: MutableSequence, idx: int) -> None:
@@ -204,7 +206,7 @@ class NodeModifier(NodeVisitor):
             elif isinstance(node, collections.abc.MutableSet):
                 items = list(enumerate(node))
 
-                def set_op(container: MutableSet, idx: Any, value: ValidNodeType) -> None:
+                def set_op(container: MutableSet, idx: Any, value: AnyTreeNode) -> None:
                     container.add(value)
 
                 def del_op(container: MutableSet, idx: int) -> None:
@@ -214,12 +216,14 @@ class NodeModifier(NodeVisitor):
                 items = node.items()
                 set_op = operator.setitem
                 del_op = operator.delitem
+
             elif isinstance(node, (collections.abc.Sequence, collections.abc.Set)):
                 # Inmutable sequence or set: create a new container instance with the new values
                 tmp_items = [self.visit(value, **kwargs) for value in node]
                 result = node.__class__(  # type: ignore
-                    [value for value in tmp_items if value is not NOTHING]
+                    [value for value in tmp_items if value is not NOTHING]  # type: ignore
                 )
+
             elif isinstance(node, collections.abc.Mapping):
                 # Inmutable mapping: create a new mapping instance with the new values
                 tmp_items = {key: self.visit(value, **kwargs) for key, value in node.items()}
@@ -234,6 +238,7 @@ class NodeModifier(NodeVisitor):
                     del_op(result, key)
                 elif new_value != value:
                     set_op(result, key, new_value)
+
         return result
 
 
@@ -245,7 +250,7 @@ class PathItemKind(enum.Enum):
 
 @dataclasses.dataclass(frozen=True)
 class PathItem:
-    node: ValidNodeType
+    node: AnyTreeNode
     kind: PathItemKind
     member: Union[str, int]
 
@@ -280,7 +285,7 @@ class PathNodeVisitor:
     ATOMIC_COLLECTION_TYPES = (str, bytes, bytearray)
 
     def visit(
-        self, node: ValidNodeType, *, path_info: Optional[PathInfo] = None, **kwargs: Any
+        self, node: AnyTreeNode, *, path_info: Optional[PathInfo] = None, **kwargs: Any
     ) -> Any:
         if path_info is None:
             path_info = PathInfo()
@@ -298,7 +303,7 @@ class PathNodeVisitor:
 
         return visitor(node, path_info=path_info, **kwargs)
 
-    def generic_visit(self, node: ValidNodeType, *, path_info: PathInfo, **kwargs: Any) -> Any:
+    def generic_visit(self, node: AnyTreeNode, *, path_info: PathInfo, **kwargs: Any) -> Any:
         items: Iterable[Tuple[Any, Any]] = []
 
         if isinstance(node, Node):

--- a/src/eve/visitors.py
+++ b/src/eve/visitors.py
@@ -28,6 +28,7 @@ from .types import IntEnum, StrEnum
 from .typing import (
     Any,
     Callable,
+    ClassVar,
     Collection,
     Iterable,
     List,
@@ -35,6 +36,7 @@ from .typing import (
     MutableSet,
     Optional,
     Tuple,
+    Type,
     TypeVar,
     Union,
 )
@@ -68,12 +70,16 @@ class NodeVisitor:
     allows modifications.
     """
 
-    ATOMIC_COLLECTION_TYPES = (str, bytes, bytearray)
+    ATOMIC_COLLECTION_TYPES: ClassVar[Tuple[Type, ...]] = (str, bytes, bytearray)
 
     def visit(self, node: AnyTreeNode, **kwargs: Any) -> Any:
         visitor = self.generic_visit
-        if isinstance(node, Node):
-            for node_class in node.__class__.__mro__:
+
+        method_name = "visit_" + node.__class__.__name__
+        if hasattr(self, method_name):
+            visitor = getattr(self, method_name)
+        elif isinstance(node, Node):
+            for node_class in node.__class__.__mro__[1:]:
                 method_name = "visit_" + node_class.__name__
                 if hasattr(self, method_name):
                     visitor = getattr(self, method_name)

--- a/src/gtc/unstructured/ugpu_codegen.py
+++ b/src/gtc/unstructured/ugpu_codegen.py
@@ -86,167 +86,35 @@ class UgpuCodeGenerator(codegen.TemplatedGenerator):
             raise ValueError("Doesn't contain a LocationType!")
         return location_type[0]
 
-    class Templates:
-        # Node = mako_tpl.Template("${_this_node.__class__.__name__.upper()}")  # only for testing
-        Connectivity = "auto {name} = gridtools::next::mesh::connectivity<{chain}>(mesh);"
+    # class Templates:
+    # Node = mako_tpl.Template("${_this_node.__class__.__name__.upper()}")  # only for testing
+    Connectivity_template = "auto {name} = gridtools::next::mesh::connectivity<{chain}>(mesh);"
 
-        NeighborChain = mako_tpl.Template(
-            """<%
-                loc_strs = [_this_generator.LOCATION_TYPE_TO_STR[e] for e in _this_node.elements]
-            %>
-            % if len(loc_strs) == 1:
-                ${ loc_strs[0] }
-            % else:
-                std::tuple<${ ','.join(loc_strs) }>
-            % endif
-            """
-        )
+    NeighborChain_template = mako_tpl.Template(
+        """<%
+            loc_strs = [_this_generator.LOCATION_TYPE_TO_STR[e] for e in _this_node.elements]
+        %>
+        % if len(loc_strs) == 1:
+            ${ loc_strs[0] }
+        % else:
+            std::tuple<${ ','.join(loc_strs) }>
+        % endif
+        """
+    )
 
-        SidCompositeNeighborTableEntry = (
-            "gridtools::next::connectivity::neighbor_table({_this_node.connectivity_deref_.name})"
-        )
+    SidCompositeNeighborTableEntry_template = (
+        "gridtools::next::connectivity::neighbor_table({_this_node.connectivity_deref_.name})"
+    )
 
-        SidCompositeEntry = "{name}"
+    SidCompositeEntry_template = "{name}"
 
-        SidComposite = mako_tpl.Template(
-            """
-            auto ${ _this_node.field_name } = tu::make<gridtools::sid::composite::keys<${ ','.join([t.tag_name for t in _this_node.entries]) }>::values>(
-            ${ ','.join(entries)});
-            static_assert(gridtools::is_sid<decltype(${ _this_node.field_name })>{});
-            """
-        )
-
-        KernelCall = mako_tpl.Template(
-            """
-            {
-                ${ ''.join(connectivities) }
-
-                ${ ''.join(sids) }
-
-                auto [blocks, threads_per_block] = gridtools::next::cuda_util::cuda_setup(gridtools::next::connectivity::size(${ primary_connectivity.name }));
-                ${ name }<<<blocks, threads_per_block>>>(${','.join(args)});
-                GT_CUDA_CHECK(cudaDeviceSynchronize());
-            }
-            """
-        )
-
-        Kernel = mako_tpl.Template(
-            """<%
-                prim_conn = symbol_tbl_conn[_this_node.primary_connectivity]
-                prim_sid = symbol_tbl_sids[_this_node.primary_sid]
-            %>
-            template<${ ','.join("class {}_t".format(p) for p in parameters)}>
-            __global__ void ${ name }( ${','.join("{0}_t {0}".format(p) for p in parameters) }) {
-                auto idx = blockIdx.x * blockDim.x + threadIdx.x;
-                if (idx >= gridtools::next::connectivity::size(${ prim_conn.name }))
-                    return;
-                % if len(prim_sid.entries) > 0:
-                auto ${ prim_sid.ptr_name } = ${ prim_sid.origin_name }();
-                gridtools::sid::shift(${ prim_sid.ptr_name }, gridtools::device::at_key<
-                    ${ _this_generator.LOCATION_TYPE_TO_STR[prim_sid.location.elements[-1]] }
-                    >(${ prim_sid.strides_name }), idx);
-                % endif
-                ${ "".join(ast) }
-            }
-            """
-        )
-
-        FieldAccess = mako_tpl.Template(
-            """<%
-                sid_deref = symbol_tbl_sids[_this_node.sid]
-                sid_entry_deref = sid_deref.symbol_tbl[_this_node.name]
-            %>*gridtools::device::at_key<${ sid_entry_deref.tag_name }>(${ sid_deref.ptr_name })"""
-        )
-
-        AssignStmt = "{left} = {right};"
-
-        BinaryOp = "({left} {op} {right})"
-
-        Computation = mako_tpl.Template(
-            """#include <gridtools/next/cuda_util.hpp>
-            #include <gridtools/next/mesh.hpp>
-            #include <gridtools/next/tmp_storage.hpp>
-            #include <gridtools/next/unstructured.hpp>
-            #include <gridtools/common/cuda_util.hpp>
-            #include <gridtools/sid/allocator.hpp>
-            #include <gridtools/sid/composite.hpp>
-
-            namespace ${ name }_impl_ {
-                ${ ''.join(sid_tags) }
-
-                ${ ''.join(kernels) }
-            }
-
-            template<class mesh_t, ${ ','.join('class ' + p.name + '_t' for p in _this_node.parameters) }>
-            void ${ name }(mesh_t&& mesh, ${ ','.join(p.name + '_t&& ' + p.name for p in _this_node.parameters) }){
-                namespace tu = gridtools::tuple_util;
-                using namespace ${ name }_impl_;
-
-                ${ cache_allocator if len(temporaries) > 0 else '' }
-                ${ ''.join(temporaries) }
-
-                ${ ''.join(ctrlflow_ast) }
-            }
-            """
-        )
-
-        Temporary = mako_tpl.Template(
-            """<%
-            %>auto zavg_tmp = gridtools::next::make_simple_tmp_storage<${ loctype }, ${ c_vtype }>(
-                (int)gridtools::next::connectivity::size(gridtools::next::mesh::connectivity<${ loctype }>(mesh)), 1 /* TODO ksize */, cuda_alloc);"""
-        )
-
-        NeighborLoop = mako_tpl.Template(
-            """<%
-                outer_sid_deref = symbol_tbl_sids[_this_node.outer_sid]
-                sid_deref = symbol_tbl_sids[_this_node.sid] if _this_node.sid else None
-                conn_deref = symbol_tbl_conn[_this_node.connectivity]
-                body_location = _this_generator.LOCATION_TYPE_TO_STR[sid_deref.location.elements[-1]] if sid_deref else None
-            %>
-            for (int neigh = 0; neigh < gridtools::next::connectivity::max_neighbors(${ conn_deref.name }); ++neigh) {
-                auto absolute_neigh_index = *gridtools::device::at_key<${ conn_deref.neighbor_tbl_tag }>(${ outer_sid_deref.ptr_name});
-                if (absolute_neigh_index != gridtools::next::connectivity::skip_value(${ conn_deref.name })) {
-                    % if sid_deref:
-                        auto ${ sid_deref.ptr_name } = ${ sid_deref.origin_name }();
-                        gridtools::sid::shift(
-                            ${ sid_deref.ptr_name }, gridtools::device::at_key<${ body_location }>(${ sid_deref.strides_name }), absolute_neigh_index);
-                    % endif
-
-                    // bodyparameters
-                    ${ ''.join(body) }
-                    // end body
-                }
-                gridtools::sid::shift(${ outer_sid_deref.ptr_name }, gridtools::device::at_key<neighbor>(${ outer_sid_deref.strides_name }), 1);
-            }
-            gridtools::sid::shift(${ outer_sid_deref.ptr_name }, gridtools::device::at_key<neighbor>(${ outer_sid_deref.strides_name }),
-                -gridtools::next::connectivity::max_neighbors(${ conn_deref.name }));
-
-            """
-        )
-
-        Literal = mako_tpl.Template(
-            """<%
-                literal= _this_node.value if isinstance(_this_node.value, str) else _this_generator.BUILTIN_LITERAL_TO_STR[_this_node.value]
-            %>(${ _this_generator.DATA_TYPE_TO_STR[_this_node.vtype] })${ literal }"""
-        )
-
-        VarAccess = "{name}"
-
-        VarDecl = mako_tpl.Template(
-            "${ _this_generator.DATA_TYPE_TO_STR[_this_node.vtype] } ${ name } = ${ init };"
-        )
-
-    @classmethod
-    def apply(cls, root, **kwargs) -> str:
-        symbol_tbl_resolved = SymbolTblHelper().visit(root)
-        generated_code = super().apply(symbol_tbl_resolved, **kwargs)
-        formatted_code = codegen.format_source("cpp", generated_code, style="LLVM")
-        return formatted_code
-
-    def visit_Temporary(self, node: Temporary, **kwargs):
-        c_vtype = self.DATA_TYPE_TO_STR[node.vtype]
-        loctype = self.LOCATION_TYPE_TO_STR[self.location_type_from_dimensions(node.dimensions)]
-        return self.generic_visit(node, loctype=loctype, c_vtype=c_vtype, **kwargs)
+    SidComposite_template = mako_tpl.Template(
+        """
+        auto ${ _this_node.field_name } = tu::make<gridtools::sid::composite::keys<${ ','.join([t.tag_name for t in _this_node.entries]) }>::values>(
+        ${ ','.join(entries)});
+        static_assert(gridtools::is_sid<decltype(${ _this_node.field_name })>{});
+        """
+    )
 
     def visit_KernelCall(self, node: KernelCall, **kwargs):
         kernel: Kernel = kwargs["symbol_tbl_kernel"][node.name]
@@ -271,6 +139,20 @@ class UgpuCodeGenerator(codegen.TemplatedGenerator):
             **kwargs,
         )
 
+    KernelCall_template = mako_tpl.Template(
+        """
+        {
+            ${ ''.join(connectivities) }
+
+            ${ ''.join(sids) }
+
+            auto [blocks, threads_per_block] = gridtools::next::cuda_util::cuda_setup(gridtools::next::connectivity::size(${ primary_connectivity.name }));
+            ${ name }<<<blocks, threads_per_block>>>(${','.join(args)});
+            GT_CUDA_CHECK(cudaDeviceSynchronize());
+        }
+        """
+    )
+
     def visit_Kernel(self, node: Kernel, **kwargs):
         symbol_tbl_conn = {c.name: c for c in node.connectivities}
         symbol_tbl_sids = {s.name: s for s in node.sids}
@@ -289,6 +171,38 @@ class UgpuCodeGenerator(codegen.TemplatedGenerator):
             **kwargs,
         )
 
+    Kernel_template = mako_tpl.Template(
+        """<%
+            prim_conn = symbol_tbl_conn[_this_node.primary_connectivity]
+            prim_sid = symbol_tbl_sids[_this_node.primary_sid]
+        %>
+        template<${ ','.join("class {}_t".format(p) for p in parameters)}>
+        __global__ void ${ name }( ${','.join("{0}_t {0}".format(p) for p in parameters) }) {
+            auto idx = blockIdx.x * blockDim.x + threadIdx.x;
+            if (idx >= gridtools::next::connectivity::size(${ prim_conn.name }))
+                return;
+            % if len(prim_sid.entries) > 0:
+            auto ${ prim_sid.ptr_name } = ${ prim_sid.origin_name }();
+            gridtools::sid::shift(${ prim_sid.ptr_name }, gridtools::device::at_key<
+                ${ _this_generator.LOCATION_TYPE_TO_STR[prim_sid.location.elements[-1]] }
+                >(${ prim_sid.strides_name }), idx);
+            % endif
+            ${ "".join(ast) }
+        }
+        """
+    )
+
+    FieldAccess_template = mako_tpl.Template(
+        """<%
+            sid_deref = symbol_tbl_sids[_this_node.sid]
+            sid_entry_deref = sid_deref.symbol_tbl[_this_node.name]
+        %>*gridtools::device::at_key<${ sid_entry_deref.tag_name }>(${ sid_deref.ptr_name })"""
+    )
+
+    AssignStmt_template = "{left} = {right};"
+
+    BinaryOp_template = "({left} {op} {right})"
+
     def visit_Computation(self, node: Computation, **kwargs):
         symbol_tbl_kernel = {k.name: k for k in node.kernels}
         sid_tags = set()
@@ -306,3 +220,89 @@ class UgpuCodeGenerator(codegen.TemplatedGenerator):
             symbol_tbl_kernel=symbol_tbl_kernel,
             **kwargs,
         )
+
+    Computation_template = mako_tpl.Template(
+        """#include <gridtools/next/cuda_util.hpp>
+        #include <gridtools/next/mesh.hpp>
+        #include <gridtools/next/tmp_storage.hpp>
+        #include <gridtools/next/unstructured.hpp>
+        #include <gridtools/common/cuda_util.hpp>
+        #include <gridtools/sid/allocator.hpp>
+        #include <gridtools/sid/composite.hpp>
+
+        namespace ${ name }_impl_ {
+            ${ ''.join(sid_tags) }
+
+            ${ ''.join(kernels) }
+        }
+
+        template<class mesh_t, ${ ','.join('class ' + p.name + '_t' for p in _this_node.parameters) }>
+        void ${ name }(mesh_t&& mesh, ${ ','.join(p.name + '_t&& ' + p.name for p in _this_node.parameters) }){
+            namespace tu = gridtools::tuple_util;
+            using namespace ${ name }_impl_;
+
+            ${ cache_allocator if len(temporaries) > 0 else '' }
+            ${ ''.join(temporaries) }
+
+            ${ ''.join(ctrlflow_ast) }
+        }
+        """
+    )
+
+    def visit_Temporary(self, node: Temporary, **kwargs):
+        c_vtype = self.DATA_TYPE_TO_STR[node.vtype]
+        loctype = self.LOCATION_TYPE_TO_STR[self.location_type_from_dimensions(node.dimensions)]
+        return self.generic_visit(node, loctype=loctype, c_vtype=c_vtype, **kwargs)
+
+    Temporary_template = mako_tpl.Template(
+        """<%
+        %>auto zavg_tmp = gridtools::next::make_simple_tmp_storage<${ loctype }, ${ c_vtype }>(
+            (int)gridtools::next::connectivity::size(gridtools::next::mesh::connectivity<${ loctype }>(mesh)), 1 /* TODO ksize */, cuda_alloc);"""
+    )
+
+    NeighborLoop_template = mako_tpl.Template(
+        """<%
+            outer_sid_deref = symbol_tbl_sids[_this_node.outer_sid]
+            sid_deref = symbol_tbl_sids[_this_node.sid] if _this_node.sid else None
+            conn_deref = symbol_tbl_conn[_this_node.connectivity]
+            body_location = _this_generator.LOCATION_TYPE_TO_STR[sid_deref.location.elements[-1]] if sid_deref else None
+        %>
+        for (int neigh = 0; neigh < gridtools::next::connectivity::max_neighbors(${ conn_deref.name }); ++neigh) {
+            auto absolute_neigh_index = *gridtools::device::at_key<${ conn_deref.neighbor_tbl_tag }>(${ outer_sid_deref.ptr_name});
+            if (absolute_neigh_index != gridtools::next::connectivity::skip_value(${ conn_deref.name })) {
+                % if sid_deref:
+                    auto ${ sid_deref.ptr_name } = ${ sid_deref.origin_name }();
+                    gridtools::sid::shift(
+                        ${ sid_deref.ptr_name }, gridtools::device::at_key<${ body_location }>(${ sid_deref.strides_name }), absolute_neigh_index);
+                % endif
+
+                // bodyparameters
+                ${ ''.join(body) }
+                // end body
+            }
+            gridtools::sid::shift(${ outer_sid_deref.ptr_name }, gridtools::device::at_key<neighbor>(${ outer_sid_deref.strides_name }), 1);
+        }
+        gridtools::sid::shift(${ outer_sid_deref.ptr_name }, gridtools::device::at_key<neighbor>(${ outer_sid_deref.strides_name }),
+            -gridtools::next::connectivity::max_neighbors(${ conn_deref.name }));
+
+        """
+    )
+
+    Literal_template = mako_tpl.Template(
+        """<%
+            literal= _this_node.value if isinstance(_this_node.value, str) else _this_generator.BUILTIN_LITERAL_TO_STR[_this_node.value]
+        %>(${ _this_generator.DATA_TYPE_TO_STR[_this_node.vtype] })${ literal }"""
+    )
+
+    VarAccess_template = "{name}"
+
+    VarDecl_template = mako_tpl.Template(
+        "${ _this_generator.DATA_TYPE_TO_STR[_this_node.vtype] } ${ name } = ${ init };"
+    )
+
+    @classmethod
+    def apply(cls, root, **kwargs) -> str:
+        symbol_tbl_resolved = SymbolTblHelper().visit(root)
+        generated_code = super().apply(symbol_tbl_resolved, **kwargs)
+        formatted_code = codegen.format_source("cpp", generated_code, style="LLVM")
+        return formatted_code

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,1 @@
+coverage_html/


### PR DESCRIPTION
List of changes:

- Fix mypy issues 
- Generic implementation of Template subclasses for different template engines
- TemplatedGenerator looks for templates in the class dict (the same as methods) instead of in the internal Templates class
- Custom visit_ methods might be defined for any type, not only for Node subclasses
- Changes in dependencies versions
- Changes in pre-commit and setup.cfg config

TODO after this PR (changes made by havogt):
- re-enable mypy in pre-commit, was disabled due to an error for python 3.8 which I couldn't solve