### PR TITLE
Gitpod - Added nvidia-toolkit to gitpod

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -11,7 +11,8 @@ RUN apt-get update -qq && \
 RUN cd /tmp && \
     wget https://developer.download.nvidia.com/compute/cuda/11.0.3/local_installers/cuda_11.0.3_450.51.06_linux.run && \
     sudo sh cuda_11.0.3_450.51.06_linux.run --silent --toolkit && \
-    rm cuda_11.0.3_450.51.06_linux.run
+    rm cuda_11.0.3_450.51.06_linux.run && \
+    echo "PATH=\$PATH:/usr/local/cuda-11.0/bin" >> $HOME/.bashrc
 
 ARG ECBUILD_VERSION=3.3.2
 RUN cd /tmp && \

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -8,6 +8,11 @@ RUN apt-get update -qq && \
     ccache && \
     rm -rf /var/lib/apt/lists/*
 
+RUN cd /tmp && \
+    wget https://developer.download.nvidia.com/compute/cuda/11.0.3/local_installers/cuda_11.0.3_450.51.06_linux.run && \
+    sudo sh cuda_11.0.3_450.51.06_linux.run --silent --toolkit && \
+    rm cuda_11.0.3_450.51.06_linux.run
+
 ARG ECBUILD_VERSION=3.3.2
 RUN cd /tmp && \
     wget -q https://github.com/ecmwf/ecbuild/archive/${ECBUILD_VERSION}.tar.gz && \


### PR DESCRIPTION
It's quite useful to at least compile the cuda based examples on gitpod (@anstaf is using this), so I've added the nvidia-toolkit to the docker image. Since the version packaged with ubuntu is too old and the one in the apt repository of nvidia requires installation of the driver and opengl libraries (lots and lots of packages) I used the local installation method.